### PR TITLE
dcu token contract is updated

### DIFF
--- a/contracts/tokens/DCUToken.sol
+++ b/contracts/tokens/DCUToken.sol
@@ -19,12 +19,22 @@ contract DCUToken is ERC20, Ownable {
         uint256 newBalance,
         uint256 timestamp
     );
-    
-    constructor() ERC20("DCU Token", "DCU") Ownable(msg.sender) {
+    address public immutable rewardLogicContract;
+    uint256 public immutable maxSupply;
+    constructor(address _rewardLogicContract, uint256 _maxSupply) ERC20("DCU Token", "DCU") Ownable(msg.sender) {
         // Initial supply can be minted here if needed
+        require(_rewardLogicContract != address(0), "Invalid RewardLogic address");
+        rewardLogicContract = _rewardLogicContract;
+        maxSupply = _maxSupply;
+    }
+    // Modifier to restrict minting to only RewardLogic contract
+    modifier onlyRewardLogic() {
+    require(msg.sender == rewardLogicContract, "Only RewardLogic Contract can mint");
+    _;
     }
 
-    function mint(address to, uint256 amount) external onlyOwner returns (bool) {
+    function mint(address to, uint256 amount) external onlyRewardLogic returns (bool) {
+        require(totalSupply() + amount <= maxSupply, "Max supply reached");
         _mint(to, amount);
         
         // Emit detailed minting event


### PR DESCRIPTION
Issue #35
Updated DCUToken Contract:
Now, only RewardLogic Contract would be able to call the mint function in the DCUToken Contract 
A max supply cap is set 
So that RewardLogic Contract can call the mint functions to mint DCU Tokens and they would be distributed to the users when the claim the rewards